### PR TITLE
Update import statements

### DIFF
--- a/challenges/1.3.Input/lesson_tests.py
+++ b/challenges/1.3.Input/lesson_tests.py
@@ -1,11 +1,8 @@
 import unittest
-import lesson_code
+from main import *
 
 class InputTests(unittest.TestCase):
     def test_main(self):
-        name = lesson_code.Name
-        age = lesson_code.Age
-
         self.assertIsInstance(name, str)
         self.assertIsInstance(age, str)
 # To run the tests from the console:

--- a/challenges/2.1.NumberTypes/lesson_tests.py
+++ b/challenges/2.1.NumberTypes/lesson_tests.py
@@ -1,11 +1,8 @@
 import unittest
-import lesson_code
+from main import *
 
 class NumbersTests(unittest.TestCase):
     def test_main(self):
-        myInteger = lesson_code.myInteger
-        myFloat = lesson_code.myFloat
-        myComplex = lesson_code.myComplex
         self.assertIsInstance(myInteger, int)
         self.assertIsInstance(myFloat, float)
         self.assertIsInstance(myComplex, complex)

--- a/challenges/2.2.Strings/lesson_tests.py
+++ b/challenges/2.2.Strings/lesson_tests.py
@@ -1,12 +1,8 @@
 import unittest
-import lesson_code
+from main import *
 
 class StringsTests(unittest.TestCase):
     def test_main(self):
-        myName = lesson_code.myName
-        myAge = lesson_code.myAge
-        favoriteActivity = lesson_code.favoriteActivity
-        mySentence = lesson_code.mySentence
         self.assertIsInstance(myName, str)
         self.assertIsInstance(myAge, str)
         self.assertIsInstance(favoriteActivity, str)

--- a/challenges/2.3.Tuples/lesson_tests.py
+++ b/challenges/2.3.Tuples/lesson_tests.py
@@ -1,12 +1,8 @@
 import unittest
-import lesson_code
+from main import *
 
 class StringsTests(unittest.TestCase):
     def test_main(self):
-        twoTuple = lesson_code.twoTuple
-        threeTuple = lesson_code.threeTuple
-        fiveTuple = lesson_code.fiveTuple
-        tenTuple = lesson_code.tenTuple
         self.assertIsInstance(twoTuple, tuple)
         self.assertIsInstance(threeTuple, tuple)
         self.assertIsInstance(fiveTuple, tuple)
@@ -15,4 +11,3 @@ class StringsTests(unittest.TestCase):
         self.assertEqual(len(threeTuple), 3)
         self.assertEqual(len(fiveTuple), 5)
         self.assertEqual(len(tenTuple), 10)
-        

--- a/challenges/2.4.Lists/lesson_tests.py
+++ b/challenges/2.4.Lists/lesson_tests.py
@@ -1,16 +1,11 @@
 import unittest
-import lesson_code
+from main import *
 
 class StringsTests(unittest.TestCase):
     def test_main(self):
-        mediumList = lesson_code.mediumList
-        shortList = lesson_code.shortList
-        longList = lesson_code.longList
-        
         self.assertIsInstance(mediumList, list)
         self.assertIsInstance(shortList, list)
         self.assertIsInstance(longList, list)
-
         self.assertEqual(len(mediumList), 5)
         self.assertEqual(len(shortList), 2)
         self.assertEqual(len(longList), 7)

--- a/challenges/2.5.Sets/lesson_tests.py
+++ b/challenges/2.5.Sets/lesson_tests.py
@@ -1,9 +1,7 @@
 import unittest
-import lesson_code
+from main import *
 
 class StringsTests(unittest.TestCase):
     def test_main(self):
-        fccSet = lesson_code.fccSet
-
         self.assertIsInstance(fccSet, set)
         self.assertEqual(len(fccSet), 14)

--- a/challenges/3.1.Assignment_Operator/lesson_tests.py
+++ b/challenges/3.1.Assignment_Operator/lesson_tests.py
@@ -1,8 +1,7 @@
 import unittest
-import lesson_code
+from main import *
 
 class AssignmentOperatorTests(unittest.TestCase):
     def test_main(self):
-        my_name = lesson_code.my_name
         self.assertIsNotNone(my_name)
         self.assertIsInstance(my_name, str)

--- a/challenges/3.2.Equality_Operator/lesson_tests.py
+++ b/challenges/3.2.Equality_Operator/lesson_tests.py
@@ -1,5 +1,5 @@
 import unittest
-from lesson_code import equality
+from main import *
 
 class EqualityOperatorTests(unittest.TestCase):
     def test_main(self):
@@ -9,7 +9,7 @@ class EqualityOperatorTests(unittest.TestCase):
         self.assertNotEqual(equality(12), 'Not Equal to 12')
 
     def test_operator_presence(self):
-        f = open('lesson_code.py')
+        f = open('main.py')
         lines = str(f.readlines())
         f.close()
         self.assertRegex(lines, '==', msg="The == operator is not in the function definition")

--- a/challenges/3.3.Inequality_Operator/lesson_tests.py
+++ b/challenges/3.3.Inequality_Operator/lesson_tests.py
@@ -1,5 +1,5 @@
 import unittest
-from inequality_operator_code import inequality
+from main import *
 
 class InEqualityOperatorTests(unittest.TestCase):
     def test_main(self):
@@ -9,7 +9,7 @@ class InEqualityOperatorTests(unittest.TestCase):
         self.assertNotEqual(inequality(13), 'Not Equal to 13')
 
     def test_operator_presence(self):
-        f = open('inequality_operator_code.py')
+        f = open('main.py')
         lines = str(f.readlines())
         f.close()
         self.assertRegex(lines, '!=', msg="The != operator is not in the function definition")

--- a/challenges/3.4.Strictly_Less_Than_Operator/lesson_tests.py
+++ b/challenges/3.4.Strictly_Less_Than_Operator/lesson_tests.py
@@ -1,5 +1,5 @@
 import unittest
-from lesson_code import strictly_less_than
+from main import *
 
 class StrictlyLessThanOperatorTests(unittest.TestCase):
     def test_main(self):
@@ -13,7 +13,7 @@ class StrictlyLessThanOperatorTests(unittest.TestCase):
         self.assertEqual(strictly_less_than(110), "100 or more")
 
     def test_operator_presence(self):
-        f = open('lesson_code.py')
+        f = open('main.py')
         lines = str(f.readlines())
         f.close()
         self.assertRegex(lines, '<', msg="The < operator is not in the function definition")

--- a/challenges/3.5.Less_Than_Equal_To_Operator/lesson_tests.py
+++ b/challenges/3.5.Less_Than_Equal_To_Operator/lesson_tests.py
@@ -1,5 +1,5 @@
 import unittest
-from lesson_code import less_or_equal
+from main import *
 
 class GreaterThanEqualToOperatorTests(unittest.TestCase):
     def test_main(self):
@@ -13,7 +13,7 @@ class GreaterThanEqualToOperatorTests(unittest.TestCase):
         self.assertEqual(less_or_equal(100), "More than 75")
 
     def test_operator_presence(self):
-        f = open('lesson_code.py')
+        f = open('main.py')
         lines = str(f.readlines())
         f.close()
         self.assertRegex(lines, '<=', msg="The <= operator is not in the function definition")

--- a/challenges/3.6.Greater_Than_Equal_To_Operator/lesson_tests.py
+++ b/challenges/3.6.Greater_Than_Equal_To_Operator/lesson_tests.py
@@ -1,5 +1,5 @@
 import unittest
-from lesson_code import greater_or_equal
+from main import *
 
 class GreaterThanEqualToOperatorTests(unittest.TestCase):
     def test_main(self):
@@ -13,7 +13,7 @@ class GreaterThanEqualToOperatorTests(unittest.TestCase):
         self.assertEqual(greater_or_equal(51), "50 or more")
 
     def test_operator_presence(self):
-        f = open('lesson_code.py')
+        f = open('main.py')
         lines = str(f.readlines())
         f.close()
         self.assertRegex(lines, '>=', msg="The >= operator is not in the function definition")

--- a/challenges/3.7.Strictly_Greater_Than_Operator/lesson_tests.py
+++ b/challenges/3.7.Strictly_Greater_Than_Operator/lesson_tests.py
@@ -1,5 +1,5 @@
 import unittest
-from lesson_code import strictly_greater_than
+from main import *
 
 class StrictlyGreaterThanOperatorTests(unittest.TestCase):
     def test_main(self):
@@ -14,7 +14,7 @@ class StrictlyGreaterThanOperatorTests(unittest.TestCase):
         self.assertEqual(strictly_greater_than(111), "Greater than 100")
 
     def test_operator_presence(self):
-        f = open('lesson_code.py')
+        f = open('main.py')
         lines = str(f.readlines())
         f.close()
         self.assertRegex(lines, '>', msg="The > operator is not in the function definition")

--- a/challenges/3.8.False_Operator/lesson_tests.py
+++ b/challenges/3.8.False_Operator/lesson_tests.py
@@ -1,6 +1,5 @@
 import unittest
-import lesson_code
-from lesson_code import boolean_false
+from main import *
 
 class BooleanFalseKeywordTests(unittest.TestCase):
     def test_main(self):

--- a/challenges/3.9.True_Operator/lesson_tests.py
+++ b/challenges/3.9.True_Operator/lesson_tests.py
@@ -1,6 +1,5 @@
 import unittest
-import lesson_code
-from lesson_code import boolean_true
+from main import *
 
 class BooleanTrueKeywordTests(unittest.TestCase):
     def test_main(self):

--- a/challenges/3.A.Logical_And_Operator/lesson_tests.py
+++ b/challenges/3.A.Logical_And_Operator/lesson_tests.py
@@ -1,6 +1,5 @@
 import unittest
-import lesson_code
-from lesson_code import boolean_and
+from main import *
 
 class BooleanAndOperatorTests(unittest.TestCase):
     def test_main(self):

--- a/challenges/3.B.Logical_Not_Operator/lesson_tests.py
+++ b/challenges/3.B.Logical_Not_Operator/lesson_tests.py
@@ -1,6 +1,5 @@
 import unittest
-import lesson_code
-from lesson_code import boolean_not
+from main import *
 
 class BooleanNotOperatorTests(unittest.TestCase):
     def test_main(self):

--- a/challenges/3.C.Logical_Or_Operator/lesson_tests.py
+++ b/challenges/3.C.Logical_Or_Operator/lesson_tests.py
@@ -1,6 +1,5 @@
 import unittest
-import lesson_code
-from lesson_code import boolean_or
+from main import *
 
 class BooleanOrOperatorTests(unittest.TestCase):
     def test_main(self):

--- a/challenges/3.D.Is_Operator/lesson_tests.py
+++ b/challenges/3.D.Is_Operator/lesson_tests.py
@@ -1,5 +1,5 @@
 import unittest
-from lesson_code import identity_test
+from main import *
 
 class IdentityOperatorTests(unittest.TestCase):
     def test_main(self):

--- a/challenges/3.E.Is_Not_Operator/lesson_tests.py
+++ b/challenges/3.E.Is_Not_Operator/lesson_tests.py
@@ -1,5 +1,5 @@
 import unittest
-from lesson_code import negative_identity_test
+from main import *
 
 class NegativeIdentityOperatorTests(unittest.TestCase):
     def test_main(self):

--- a/challenges/3.F.In_Operator/lesson_tests.py
+++ b/challenges/3.F.In_Operator/lesson_tests.py
@@ -1,11 +1,8 @@
 import unittest
-import lesson_code
-from lesson_code import membership_test
+from main import *
 
 class TestMembership(unittest.TestCase):
     def test_main(self):
-        word = lesson_code.word
-        sentence = lesson_code.sentence
         self.assertIsNotNone(membership_test())
         self.assertEqual(membership_test(), True)
         self.assertTrue(membership_test())

--- a/challenges/3.G.Not_In_Operator/lesson_tests.py
+++ b/challenges/3.G.Not_In_Operator/lesson_tests.py
@@ -1,11 +1,8 @@
 import unittest
-import lesson_code
-from lesson_code import non_membership_test
+from main import *
 
 class TestNonMembership(unittest.TestCase):
     def test_main(self):
-        letter = lesson_code.letter
-        alphabet = lesson_code.alphabet
         self.assertIsNotNone(non_membership_test())
         self.assertEqual(non_membership_test(), True)
         self.assertTrue(non_membership_test())

--- a/challenges/4.1.Addition/lesson_tests.py
+++ b/challenges/4.1.Addition/lesson_tests.py
@@ -1,9 +1,8 @@
 import unittest
-import lesson_code
+from main import *
 
 class AdditionTests(unittest.TestCase):
     def test_main(self):
-        total = lesson_code.total
         self.assertIsInstance(total, int)
         self.assertEqual(total, 20)
 

--- a/challenges/4.2.Subtraction/lesson_tests.py
+++ b/challenges/4.2.Subtraction/lesson_tests.py
@@ -1,9 +1,8 @@
 import unittest
-import lesson_code
+from main import *
 
 class SubtractionTests(unittest.TestCase):
     def test_main(self):
-        total = lesson_code.total
         self.assertIsInstance(total, int)
         self.assertEqual(total, 10)
 

--- a/challenges/4.3.Multiplication/lesson_tests.py
+++ b/challenges/4.3.Multiplication/lesson_tests.py
@@ -1,8 +1,7 @@
 import unittest
-import lesson_code
+from main import *
 
 class MultiplicationTests(unittest.TestCase):
     def test_main(self):
-        product = lesson_code.product
         self.assertIsInstance(product, int)
         self.assertEqual(product, 80)

--- a/challenges/4.4.Float_Division/lesson_tests.py
+++ b/challenges/4.4.Float_Division/lesson_tests.py
@@ -1,8 +1,7 @@
 import unittest
-import lesson_code
+from main import *
 
 class FloatDivisionTests(unittest.TestCase):
     def test_main(self):
-        quotient = lesson_code.quotient
         self.assertIsInstance(quotient, float)
         self.assertEqual(quotient, 2.5)

--- a/challenges/4.5.Integer_Division/lesson_tests.py
+++ b/challenges/4.5.Integer_Division/lesson_tests.py
@@ -1,8 +1,7 @@
 import unittest
-import lesson_code
+from main import *
 
 class IntegerDivisionTests(unittest.TestCase):
     def test_main(self):
-        quotient = lesson_code.quotient
         self.assertIsInstance(quotient, int)
         self.assertEqual(quotient, 2)

--- a/challenges/4.6.Exponents/lesson_tests.py
+++ b/challenges/4.6.Exponents/lesson_tests.py
@@ -1,8 +1,7 @@
 import unittest
-import lesson_code
+from main import *
 
 class ExponentsTests(unittest.TestCase):
-    def test_main(self):
-        power = lesson_code.power 
+    def test_main(self): 
         self.assertIsInstance(power, int)
         self.assertEqual(power, 81)

--- a/challenges/4.7.Remainder/lesson_tests.py
+++ b/challenges/4.7.Remainder/lesson_tests.py
@@ -1,8 +1,7 @@
 import unittest
-import lesson_code
+from main import *
 
 class RemainderTests(unittest.TestCase):
     def test_main(self):
-        remainder = lesson_code.remainder
         self.assertIsInstance(remainder, int)
         self.assertEqual(remainder, 2)

--- a/challenges/4.8.Divmod/lesson_tests.py
+++ b/challenges/4.8.Divmod/lesson_tests.py
@@ -1,8 +1,7 @@
 import unittest
-import lesson_code
+from main import *
 
 class DivmodTests(unittest.TestCase):
     def test_main(self):
-        result = lesson_code.result
         self.assertIsInstance(result, tuple)
         self.assertEqual(result, (3, 2))

--- a/challenges/4.9.Square_Root/lesson_tests.py
+++ b/challenges/4.9.Square_Root/lesson_tests.py
@@ -1,8 +1,7 @@
 import unittest
-import lesson_code
+from main import *
 
 class SquareRootTests(unittest.TestCase):
-    def test_main(self):
-        square_root = lesson_code.square_root 
+    def test_main(self): 
         self.assertIsInstance(square_root, float)
         self.assertEqual(square_root, 9.0)

--- a/challenges/4.A.Sum/lesson_tests.py
+++ b/challenges/4.A.Sum/lesson_tests.py
@@ -1,8 +1,7 @@
 import unittest
-import lesson_code
+from main import *
 
 class SumTests(unittest.TestCase):
-    def test_main(self):
-        total = lesson_code.total 
+    def test_main(self): 
         self.assertIsInstance(total, int)
         self.assertEqual(total, 55)

--- a/challenges/4.B.Rounding/lesson_tests.py
+++ b/challenges/4.B.Rounding/lesson_tests.py
@@ -1,8 +1,7 @@
 import unittest
-import lesson_code
+from main import *
 
 class RoundingTests(unittest.TestCase):
     def test_main(self):
-        shorter_pi = lesson_code.shorter_pi
         self.assertIsInstance(shorter_pi, float)
         self.assertEqual(shorter_pi, 3.14)

--- a/challenges/4.C.Absolute_Value/lesson_tests.py
+++ b/challenges/4.C.Absolute_Value/lesson_tests.py
@@ -1,8 +1,7 @@
 import unittest
-import lesson_code
+from main import *
 
 class AbsoluteValueTests(unittest.TestCase):
-    def test_main(self):
-        absolute_value = lesson_code.absolute_value 
+    def test_main(self): 
         self.assertIsInstance(absolute_value, int)
         self.assertEqual(absolute_value, 42)

--- a/challenges/4.D.Min_Value/lesson_tests.py
+++ b/challenges/4.D.Min_Value/lesson_tests.py
@@ -1,8 +1,7 @@
 import unittest
-import lesson_code
+from main import *
 
 class MinValueTests(unittest.TestCase):
     def test_main(self):
-        lowest = lesson_code.lowest
         self.assertIsInstance(lowest, int)
         self.assertEqual(lowest, 1)

--- a/challenges/4.E.Max_Value/lesson_tests.py
+++ b/challenges/4.E.Max_Value/lesson_tests.py
@@ -1,8 +1,7 @@
 import unittest
-import lesson_code
+from main import *
 
 class MaxValueTests(unittest.TestCase):
-    def test_main(self):
-        highest = lesson_code.highest 
+    def test_main(self): 
         self.assertIsInstance(highest, int)
         self.assertEqual(highest, 9)


### PR DESCRIPTION
This PR addresses Issue #28 Ref [#8 (comment)](https://github.com/freeCodeCamp/python-coding-challenges/issues/8#issuecomment-307966210).  
Import statements in the lesson_tests.py files for each of the challenges have been updated to use `from main import *`.  
The old import statements have been removed.
Changing the import statements caused some variable assignments in the test files to become unnecessary, so I also removed those.  
In addition, changing the name of the challenge files from `lesson_code.py` to `main.py` broke some of the challenges' unit tests, so I fixed those as well. 